### PR TITLE
Revert "Fix redirection within group calendar"

### DIFF
--- a/static/js/GroupCalendar.js
+++ b/static/js/GroupCalendar.js
@@ -112,7 +112,7 @@ function removeByValue(arr, val) {
 //return the calendar owner's edit page
 function returnEdit(){
         var user = getParameterByName("username")
-        window.location.href = "/QuickMeet/default/index?"+"username="+user
+        window.location.href = "http://127.0.0.1:8000/Quickmeet/default/index?"+"username="+user
 }
 
 


### PR DESCRIPTION
Reverts drgmonkey/QuickMeet#73
Master is currently broken, please approve this to bring master back to working state before modifying the drawBox.
This should bring all the posting data back to normal.